### PR TITLE
Fixed a double import issue in TdrStyles.py

### DIFF
--- a/python/myutils/TdrStyles.py
+++ b/python/myutils/TdrStyles.py
@@ -1,8 +1,7 @@
 import ROOT
-from ROOT import TStyle
 
 def tdrStyle():
-  tdrStyle = TStyle("tdrStyle","Style for P-TDR")
+  tdrStyle = ROOT.TStyle("tdrStyle","Style for P-TDR")
 
 # For the canvas:
   tdrStyle.SetCanvasBorderMode(0) 


### PR DESCRIPTION
This was discovered by looking at the stack trace when ROOT segfaulted
after calling a Python script with -h or --help.
